### PR TITLE
Fix call transform.translate error after call transform.position = new Vector3(x, x, x)

### DIFF
--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -754,9 +754,9 @@ export class Transform extends Component {
     if (relativeToLocal) {
       const { _tempVec30 } = Transform;
       Vector3.transformByQuat(translation, this.worldRotationQuaternion, _tempVec30);
-      this._worldPosition.add(_tempVec30);
+      this.worldPosition.add(_tempVec30);
     } else {
-      this._worldPosition.add(translation);
+      this.worldPosition.add(translation);
     }
   }
 


### PR DESCRIPTION
```typescript
const entity = rootEntity.createChild('test');
const { transform } = entity;
transform.position = new Vector3(100, 0, 0);
transform.translate(1, 0, 0);
console.log(transform.worldPosition.x);
```
expected output: 101
actual output: 1
