### PR TITLE
Fix by passing 0.0 avoids precision issues and optimizes performance

### DIFF
--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -4,19 +4,22 @@
 		for(int i = 0; i < RENDERER_BLENDSHAPE_COUNT; i++){
 			int vertexElementOffset = vertexOffset;
 			float weight = renderer_BlendShapeWeights[i];
-			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
-			
-			#ifndef MATERIAL_OMIT_NORMAL
-				#if defined( RENDERER_HAS_NORMAL ) && defined( RENDERER_BLENDSHAPE_HAS_NORMAL )
-					vertexElementOffset += 1;
-					normal += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
-				#endif
+			if(weight != 0.0){
+				position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 
-				#if defined( RENDERER_HAS_TANGENT ) && defined(RENDERER_BLENDSHAPE_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEAR_COAT_NORMAL_TEXTURE) )
-					vertexElementOffset += 1;
-					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
+				#ifndef MATERIAL_OMIT_NORMAL
+					#if defined( RENDERER_HAS_NORMAL ) && defined( RENDERER_BLENDSHAPE_HAS_NORMAL )
+						vertexElementOffset += 1;
+						normal += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
+					#endif
+
+					#if defined( RENDERER_HAS_TANGENT ) && defined(RENDERER_BLENDSHAPE_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEAR_COAT_NORMAL_TEXTURE) )
+						vertexElementOffset += 1;
+						tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
+					#endif
 				#endif
-			#endif
+			}
+			
 		}
 	#else
 		position.xyz += POSITION_BS0 * renderer_BlendShapeWeights[0];

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -4,15 +4,16 @@
 		for(int i = 0; i < RENDERER_BLENDSHAPE_COUNT; i++){
 			int vertexElementOffset = vertexOffset;
 			float weight = renderer_BlendShapeWeights[i];
+			// Warnning: Multiplying by 0 creates weird precision issues, causing rendering anomalies in Ace2 Android13
 			if(weight != 0.0){
 				position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
-
+	
 				#ifndef MATERIAL_OMIT_NORMAL
 					#if defined( RENDERER_HAS_NORMAL ) && defined( RENDERER_BLENDSHAPE_HAS_NORMAL )
 						vertexElementOffset += 1;
 						normal += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 					#endif
-
+	
 					#if defined( RENDERER_HAS_TANGENT ) && defined(RENDERER_BLENDSHAPE_HAS_TANGENT) && ( defined(MATERIAL_HAS_NORMALTEXTURE) || defined(MATERIAL_HAS_CLEAR_COAT_NORMAL_TEXTURE) )
 						vertexElementOffset += 1;
 						tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
fix https://aone.alipay.com/v2/project/22200295/bug/101324332#

```
  if(i == 51 && weight == 0.0){
​        weight = 0.0; // This sentence is very important and indicates the existence of accuracy issues.
​        position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
​    }else{
​        position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
​    }
```