### PR TITLE
Feat: temporary resolution of submesh rendering order

### DIFF
--- a/packages/core/src/RenderPipeline/RenderQueue.ts
+++ b/packages/core/src/RenderPipeline/RenderQueue.ts
@@ -17,6 +17,7 @@ export class RenderQueue {
   static _compareFromNearToFar(a: RenderElement, b: RenderElement): number {
     return (
       a.data.component.priority - b.data.component.priority ||
+      a.data.material._priority - b.data.material._priority ||
       a.data.component._distanceForSort - b.data.component._distanceForSort
     );
   }
@@ -27,6 +28,7 @@ export class RenderQueue {
   static _compareFromFarToNear(a: RenderElement, b: RenderElement): number {
     return (
       a.data.component.priority - b.data.component.priority ||
+      a.data.material._priority - b.data.material._priority ||
       b.data.component._distanceForSort - a.data.component._distanceForSort
     );
   }

--- a/packages/core/src/material/Material.ts
+++ b/packages/core/src/material/Material.ts
@@ -18,6 +18,8 @@ export class Material extends ReferResource implements IClone {
   _shader: Shader;
   /** @internal */
   _renderStates: RenderState[] = []; // todo: later will as a part of shaderData when shader effect frame is OK, that is more powerful and flexible.
+  /** @internal */
+  _priority: number = 0; // todo: temporary resolution of submesh rendering order issue.
 
   private _shaderData: ShaderData = new ShaderData(ShaderDataGroup.Material);
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

