### PR TITLE
Fix text renderer wrap error

### DIFF
--- a/packages/core/src/2d/text/TextUtils.ts
+++ b/packages/core/src/2d/text/TextUtils.ts
@@ -287,7 +287,6 @@ export class TextUtils {
       let maxDescent = 0;
 
       for (let j = 0, m = line.length; j < m; ++j) {
-        debugger;
         const charInfo = TextUtils._getCharInfo(line[j], fontString, subFont);
         curWidth += charInfo.xAdvance;
         const { offsetY } = charInfo;

--- a/packages/core/src/2d/text/TextUtils.ts
+++ b/packages/core/src/2d/text/TextUtils.ts
@@ -215,8 +215,8 @@ export class TextUtils {
           } else {
             word += char;
             wordWidth += charInfo.xAdvance;
-            wordMaxAscent = Math.max(wordMaxAscent, lineMaxAscent, ascent);
-            wordMaxDescent = Math.max(wordMaxDescent, lineMaxDescent, descent);
+            wordMaxAscent = Math.max(wordMaxAscent, ascent);
+            wordMaxDescent = Math.max(wordMaxDescent, descent);
           }
         }
       }

--- a/packages/core/src/2d/text/TextUtils.ts
+++ b/packages/core/src/2d/text/TextUtils.ts
@@ -215,8 +215,8 @@ export class TextUtils {
           } else {
             word += char;
             wordWidth += charInfo.xAdvance;
-            wordMaxAscent = lineMaxAscent = Math.max(wordMaxAscent, lineMaxAscent, ascent);
-            wordMaxDescent = lineMaxDescent = Math.max(wordMaxDescent, lineMaxDescent, descent);
+            wordMaxAscent = Math.max(wordMaxAscent, lineMaxAscent, ascent);
+            wordMaxDescent = Math.max(wordMaxDescent, lineMaxDescent, descent);
           }
         }
       }

--- a/packages/core/src/2d/text/TextUtils.ts
+++ b/packages/core/src/2d/text/TextUtils.ts
@@ -215,8 +215,8 @@ export class TextUtils {
           } else {
             word += char;
             wordWidth += charInfo.xAdvance;
-            wordMaxAscent = lineMaxAscent = Math.max(wordMaxAscent, ascent);
-            wordMaxDescent = lineMaxDescent = Math.max(wordMaxDescent, descent);
+            wordMaxAscent = lineMaxAscent = Math.max(wordMaxAscent, lineMaxAscent, ascent);
+            wordMaxDescent = lineMaxDescent = Math.max(wordMaxDescent, lineMaxDescent, descent);
           }
         }
       }
@@ -287,6 +287,7 @@ export class TextUtils {
       let maxDescent = 0;
 
       for (let j = 0, m = line.length; j < m; ++j) {
+        debugger;
         const charInfo = TextUtils._getCharInfo(line[j], fontString, subFont);
         curWidth += charInfo.xAdvance;
         const { offsetY } = charInfo;

--- a/tests/src/core/2d/text/TextUtils.test.ts
+++ b/tests/src/core/2d/text/TextUtils.test.ts
@@ -8,8 +8,12 @@ describe("TextUtils", () => {
   let scene: Scene;
   let textEntity1: Entity;
   let textEntity2: Entity;
+  let textEntity3: Entity;
+  let textEntity4: Entity;
   let textRendererTruncate: TextRenderer;
   let textRendererOverflow: TextRenderer;
+  let wrap1TextRenderer: TextRenderer;
+  let wrap2TextRenderer: TextRenderer;
 
   before(async function () {
     engine = await WebGLEngine.create({
@@ -29,12 +33,19 @@ describe("TextUtils", () => {
 
     textEntity1 = rootEntity.createChild("text1");
     textEntity2 = rootEntity.createChild("text2");
+    textEntity3 = rootEntity.createChild("text3");
+    textEntity4 = rootEntity.createChild("text4");
 
     textRendererTruncate = textEntity1.addComponent(TextRenderer);
     textRendererTruncate.font = Font.createFromOS(engine, "Arial");
 
     textRendererOverflow = textEntity2.addComponent(TextRenderer);
     textRendererOverflow.font = Font.createFromOS(engine, "Arial");
+
+    wrap1TextRenderer = textEntity3.addComponent(TextRenderer);
+    wrap1TextRenderer.font = Font.createFromOS(engine, "Arial");
+    wrap2TextRenderer = textEntity4.addComponent(TextRenderer);
+    wrap2TextRenderer.font = Font.createFromOS(engine, "Arial");
 
     engine.run();
   });
@@ -201,16 +212,11 @@ describe("TextUtils", () => {
     expect(result.lines).to.be.deep.equal(["  ", "  ", "W", "o", "rl", "d"]);
     expect(result.lineHeight).to.be.equal(27);
 
-    const root = scene.rootEntities[0];
-    const wrap1TextEntity = root.createChild("wrap1");
-    const wrap1TextRenderer = wrap1TextEntity.addComponent(TextRenderer);
     wrap1TextRenderer.enableWrapping = true;
     wrap1TextRenderer.width = 5;
     wrap1TextRenderer.fontSize = 60;
     wrap1TextRenderer.text = "测试";
     const text1Metrics = TextUtils.measureTextWithWrap(wrap1TextRenderer);
-    const wrap2TextEntity = root.createChild("wrap2");
-    const wrap2TextRenderer = wrap2TextEntity.addComponent(TextRenderer);
     wrap2TextRenderer.enableWrapping = true;
     wrap2TextRenderer.width = 5;
     wrap2TextRenderer.fontSize = 60;

--- a/tests/src/core/2d/text/TextUtils.test.ts
+++ b/tests/src/core/2d/text/TextUtils.test.ts
@@ -200,6 +200,23 @@ describe("TextUtils", () => {
     expect(result.height).to.be.equal(162);
     expect(result.lines).to.be.deep.equal(["  ", "  ", "W", "o", "rl", "d"]);
     expect(result.lineHeight).to.be.equal(27);
+
+    const root = scene.rootEntities[0];
+    const wrap1TextEntity = root.createChild("wrap1");
+    const wrap1TextRenderer = wrap1TextEntity.addComponent(TextRenderer);
+    wrap1TextRenderer.enableWrapping = true;
+    wrap1TextRenderer.width = 5;
+    wrap1TextRenderer.fontSize = 60;
+    wrap1TextRenderer.text = "测试";
+    const text1Metrics = TextUtils.measureTextWithWrap(wrap1TextRenderer);
+    const wrap2TextEntity = root.createChild("wrap2");
+    const wrap2TextRenderer = wrap2TextEntity.addComponent(TextRenderer);
+    wrap2TextRenderer.enableWrapping = true;
+    wrap2TextRenderer.width = 5;
+    wrap2TextRenderer.fontSize = 60;
+    wrap2TextRenderer.text = "测试。";
+    const text2Metrics = TextUtils.measureTextWithWrap(wrap2TextRenderer);
+    expect(text1Metrics.lineMaxSizes[0].size).to.be.equal(text2Metrics.lineMaxSizes[0].size);
   });
 
   it("measureTextWithoutWrap", () => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

test code
```typescript
const wrapTextEntity = rootEntity.createChild("wrap");
  wrapTextEntity.transform.setScale(60, 60, 60);
  wrapTextEntity.transform.setPosition(0, -35, 0);
  const wrapTextRenderer = wrapTextEntity.addComponent(TextRenderer);
  wrapTextRenderer.fontSize = 60;
  wrapTextRenderer.color = new Color(0, 1, 0, 1);
  wrapTextRenderer.text = "测试";
  wrapTextRenderer.width = 5;
  wrapTextRenderer.enableWrapping = true;
  setTimeout(() => {
    wrapTextRenderer.text = "测试。";
  }, 3000);
```
