### PR TITLE
Add lightmap in pbr workflow

### DIFF
--- a/packages/core/src/material/PBRBaseMaterial.ts
+++ b/packages/core/src/material/PBRBaseMaterial.ts
@@ -20,6 +20,10 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
   private static _clearCoatRoughnessTextureProp = ShaderProperty.getByName("material_ClearCoatRoughnessTexture");
   private static _clearCoatNormalTextureProp = ShaderProperty.getByName("material_ClearCoatNormalTexture");
 
+  private static _lightmapProp = ShaderProperty.getByName("material_Lightmap");
+  private static _dirLightmapProp = ShaderProperty.getByName("material_DirLightmap");
+  private static _lightmapTilingOffsetProp: ShaderProperty = ShaderProperty.getByName("material_LightmapTilingOffset");
+
   /**
    * Base color.
    */
@@ -244,6 +248,52 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
   }
 
   /**
+   * Tiling and offset of lightmap textures.
+   */
+  get lightmapTilingOffset(): Vector4 {
+    return this.shaderData.getVector4(PBRBaseMaterial._lightmapTilingOffsetProp);
+  }
+
+  set lightmapTilingOffset(value: Vector4) {
+    const tilingOffset = this.shaderData.getVector4(PBRBaseMaterial._lightmapTilingOffsetProp);
+    if (value !== tilingOffset) {
+      tilingOffset.copyFrom(value);
+    }
+  }
+
+  /**
+   * Lightmap.
+   */
+  get lightmap(): Texture2D {
+    return <Texture2D>this.shaderData.getTexture(PBRBaseMaterial._lightmapProp);
+  }
+
+  set lightmap(value: Texture2D) {
+    this.shaderData.setTexture(PBRBaseMaterial._lightmapProp, value);
+    if (value) {
+      this.shaderData.enableMacro("MATERIAL_HAS_LIGHTMAP");
+    } else {
+      this.shaderData.disableMacro("MATERIAL_HAS_LIGHTMAP");
+    }
+  }
+
+  /**
+   * Directional Lightmap.
+   */
+  get dirLightmap(): Texture2D {
+    return <Texture2D>this.shaderData.getTexture(PBRBaseMaterial._dirLightmapProp);
+  }
+
+  set dirLightmap(value: Texture2D) {
+    this.shaderData.setTexture(PBRBaseMaterial._dirLightmapProp, value);
+    if (value) {
+      this.shaderData.enableMacro("MATERIAL_HAS_DIRLIGHTMAP");
+    } else {
+      this.shaderData.disableMacro("MATERIAL_HAS_DIRLIGHTMAP");
+    }
+  }
+
+  /**
    * Create a pbr base material instance.
    * @param engine - Engine to which the material belongs
    * @param shader - Shader used by the material
@@ -266,5 +316,7 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
 
     shaderData.setFloat(PBRBaseMaterial._clearCoatProp, 0);
     shaderData.setFloat(PBRBaseMaterial._clearCoatRoughnessProp, 0);
+
+    shaderData.setVector4(PBRBaseMaterial._lightmapTilingOffsetProp, new Vector4(1, 1, 0, 0));
   }
 }

--- a/packages/core/src/shaderlib/common_vert.glsl
+++ b/packages/core/src/shaderlib/common_vert.glsl
@@ -46,6 +46,10 @@ attribute vec3 POSITION;
 
 uniform vec4 material_TilingOffset;
 
+#ifdef MATERIAL_HAS_LIGHTMAP
+    uniform vec4 material_LightmapTilingOffset;
+#endif
+
 
 #ifndef MATERIAL_OMIT_NORMAL
     #ifdef RENDERER_HAS_NORMAL

--- a/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_frag_define.glsl
@@ -19,6 +19,19 @@ vec3 getLightProbeIrradiance(vec3 sh[9], vec3 normal){
 
 }
 
+vec3 DecodeDirectionalLightmap(vec3 color, vec4 dirTex, vec3 normalWorld) {
+    // In directional (non-specular) mode Enlighten bakes dominant light direction
+    // in a way, that using it for half Lambert and then dividing by a "rebalancing coefficient"
+    // gives a result close to plain diffuse response lightmaps, but normalmapped.
+
+    // Note that dir is not unit length on purpose. Its length is "directionality", like
+    // for the directional specular lightmaps.
+
+    float halfLambert = dot(normalWorld, dirTex.xyz - 0.5) + 0.5;
+
+    return color * halfLambert / max(1e-4, dirTex.w);
+}
+
 // ------------------------Specular------------------------
 
 // ref: https://www.unrealengine.com/blog/physically-based-shading-on-mobile - environmentBRDF for GGX on mobile

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -11,8 +11,7 @@ addTotalDirectRadiance(geometry, material, reflectedLight);
 // IBL diffuse
 #ifdef MATERIAL_HAS_LIGHTMAP
     vec4 lightmapColor= texture2D(material_Lightmap, v_lightmapUV);
-    // @TODO: use RGBM format from editor bake workflow.
-    vec3 irradiance = RGBMToLinear(lightmapColor, 1.0).rgb;
+    vec3 irradiance = RGBMToLinear(lightmapColor, 5.0).rgb;
     #ifdef MATERIAL_HAS_DIRLIGHTMAP
 		vec4 dirLightmapColor = texture2D (material_DirLightmap, v_lightmapUV);
         irradiance = DecodeDirectionalLightmap (irradiance, dirLightmapColor, geometry.normal);

--- a/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
@@ -63,6 +63,13 @@ uniform float material_OcclusionTextureCoord;
     uniform sampler2D material_OcclusionTexture;
 #endif
 
+#ifdef MATERIAL_HAS_LIGHTMAP
+    uniform sampler2D material_Lightmap;
+    #ifdef MATERIAL_HAS_DIRLIGHTMAP
+        uniform sampler2D material_DirLightmap;
+    #endif
+#endif
+
 // Runtime
 struct ReflectedLight {
     vec3 directDiffuse;

--- a/packages/core/src/shaderlib/uv_share.glsl
+++ b/packages/core/src/shaderlib/uv_share.glsl
@@ -3,3 +3,7 @@ varying vec2 v_uv;
 #ifdef RENDERER_HAS_UV1
     varying vec2 v_uv1;
 #endif
+
+#ifdef MATERIAL_HAS_LIGHTMAP
+    varying vec2 v_lightmapUV;
+#endif

--- a/packages/core/src/shaderlib/uv_vert.glsl
+++ b/packages/core/src/shaderlib/uv_vert.glsl
@@ -12,3 +12,7 @@
 #ifdef MATERIAL_NEED_TILING_OFFSET
     v_uv = v_uv * material_TilingOffset.xy + material_TilingOffset.zw;
 #endif
+
+#ifdef MATERIAL_HAS_LIGHTMAP
+    v_lightmapUV = v_uv1 * material_LightmapTilingOffset.xy + material_LightmapTilingOffset.zw;
+#endif


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature, Enhance
### What is the current behavior? (You can also link to an open issue here)
use `BakePBRMaterial` in `@galacean/runtime-toolkit`
### What is the new behavior (if this is a feature change)?
add property 'lightmap'、`dirLightmap`、 `lightmapTilingOffset` in `PBRBaseMaterial`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information:
* must have uv1 channel, just `RENDERER_HAS_UV1`
* must use RGBM format and `5.0 scale factor` from editor