### PR TITLE
feat: add `fog` property for some materials

### DIFF
--- a/packages/core/src/material/BlinnPhongMaterial.ts
+++ b/packages/core/src/material/BlinnPhongMaterial.ts
@@ -12,6 +12,16 @@ export class BlinnPhongMaterial extends BaseMaterial {
   private static _specularColorProp = ShaderProperty.getByName("material_SpecularColor");
   private static _shininessProp = ShaderProperty.getByName("material_Shininess");
   private static _specularTextureProp = ShaderProperty.getByName("material_SpecularTexture");
+  private _fog: boolean = true;
+
+  get fog() {
+    return this._fog;
+  }
+
+  set fog(enableFog: boolean) {
+    this._fog = enableFog;
+    this.shaderData.enableMacro("ENABLE_FOG", `${+enableFog}`);
+  }
 
   /**
    * Base color.
@@ -166,6 +176,7 @@ export class BlinnPhongMaterial extends BaseMaterial {
 
     shaderData.enableMacro("MATERIAL_NEED_WORLD_POS");
     shaderData.enableMacro("MATERIAL_NEED_TILING_OFFSET");
+    shaderData.enableMacro("ENABLE_FOG", "1");
 
     shaderData.setColor(BlinnPhongMaterial._baseColorProp, new Color(1, 1, 1, 1));
     shaderData.setColor(BlinnPhongMaterial._specularColorProp, new Color(1, 1, 1, 1));

--- a/packages/core/src/material/PBRMaterial.ts
+++ b/packages/core/src/material/PBRMaterial.ts
@@ -1,5 +1,5 @@
 import { Engine } from "../Engine";
-import { ShaderProperty } from "../shader";
+import { ShaderMacro, ShaderProperty } from "../shader";
 import { Shader } from "../shader/Shader";
 import { Texture2D } from "../texture/Texture2D";
 import { PBRBaseMaterial } from "./PBRBaseMaterial";
@@ -13,7 +13,16 @@ export class PBRMaterial extends PBRBaseMaterial {
   private static _roughnessMetallicTextureProp = ShaderProperty.getByName("material_RoughnessMetallicTexture");
 
   private static _iorProp = Shader.getPropertyByName("material_IOR");
+  private _fog: boolean = true;
 
+  get fog() {
+    return this._fog;
+  }
+
+  set fog(enableFog: boolean) {
+    this._fog = enableFog;
+    this.shaderData.enableMacro("ENABLE_FOG", `${+enableFog}`);
+  }
   /**
    * Index Of Refraction.
    * @defaultValue `1.5`
@@ -76,6 +85,7 @@ export class PBRMaterial extends PBRBaseMaterial {
     this.shaderData.setFloat(PBRMaterial._metallicProp, 1);
     this.shaderData.setFloat(PBRMaterial._roughnessProp, 1);
     this.shaderData.setFloat(PBRMaterial._iorProp, 1.5);
+    this.shaderData.enableMacro("ENABLE_FOG", "1");
   }
 
   /**

--- a/packages/core/src/material/PBRSpecularMaterial.ts
+++ b/packages/core/src/material/PBRSpecularMaterial.ts
@@ -16,6 +16,16 @@ export class PBRSpecularMaterial extends PBRBaseMaterial {
   private static _specularGlossinessTextureMacro: ShaderMacro = ShaderMacro.getByName(
     "MATERIAL_HAS_SPECULAR_GLOSSINESS_TEXTURE"
   );
+  private _fog: boolean = true;
+
+  get fog() {
+    return this._fog;
+  }
+
+  set fog(enableFog: boolean) {
+    this._fog = enableFog;
+    this.shaderData.enableMacro("ENABLE_FOG", `${+enableFog}`);
+  }
 
   /**
    * Specular color.
@@ -68,6 +78,7 @@ export class PBRSpecularMaterial extends PBRBaseMaterial {
 
     this.shaderData.setColor(PBRSpecularMaterial._specularColorProp, new Color(1, 1, 1, 1));
     this.shaderData.setFloat(PBRSpecularMaterial._glossinessProp, 1.0);
+    this.shaderData.enableMacro("ENABLE_FOG", "1");
   }
 
   /**

--- a/packages/core/src/material/UnlitMaterial.ts
+++ b/packages/core/src/material/UnlitMaterial.ts
@@ -8,6 +8,17 @@ import { BaseMaterial } from "./BaseMaterial";
  * Unlit Material.
  */
 export class UnlitMaterial extends BaseMaterial {
+  private _fog: boolean = true;
+
+  get fog() {
+    return this._fog;
+  }
+
+  set fog(enableFog: boolean) {
+    this._fog = enableFog;
+    this.shaderData.enableMacro("ENABLE_FOG", `${+enableFog}`);
+  }
+
   /**
    * Base color.
    */
@@ -63,6 +74,7 @@ export class UnlitMaterial extends BaseMaterial {
 
     shaderData.enableMacro("MATERIAL_OMIT_NORMAL");
     shaderData.enableMacro("MATERIAL_NEED_TILING_OFFSET");
+    shaderData.enableMacro("ENABLE_FOG", "1");
 
     shaderData.setColor(UnlitMaterial._baseColorProp, new Color(1, 1, 1, 1));
     shaderData.setVector4(UnlitMaterial._tilingOffsetProp, new Vector4(1, 1, 0, 0));

--- a/packages/core/src/shaderlib/extra/blinn-phong.fs.glsl
+++ b/packages/core/src/shaderlib/extra/blinn-phong.fs.glsl
@@ -27,7 +27,9 @@ void main() {
         gl_FragColor.a = 1.0;
     #endif
 
-    #include <FogFragment>
+    #if ENABLE_FOG == 1
+        #include <FogFragment>
+    #endif    
 
     #ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);

--- a/packages/core/src/shaderlib/extra/pbr-specular.fs.glsl
+++ b/packages/core/src/shaderlib/extra/pbr-specular.fs.glsl
@@ -16,7 +16,10 @@
 
 void main() {
     #include <pbr_frag>
-    #include <FogFragment>
+
+    #if ENABLE_FOG == 1
+        #include <FogFragment>
+    #endif    
 
     #ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);

--- a/packages/core/src/shaderlib/extra/pbr.fs.glsl
+++ b/packages/core/src/shaderlib/extra/pbr.fs.glsl
@@ -16,7 +16,10 @@
 
 void main() {
     #include <pbr_frag>
-    #include <FogFragment>
+
+    #if ENABLE_FOG == 1
+        #include <FogFragment>
+    #endif    
     
     #ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);

--- a/packages/core/src/shaderlib/extra/unlit.fs.glsl
+++ b/packages/core/src/shaderlib/extra/unlit.fs.glsl
@@ -32,7 +32,9 @@ void main() {
         gl_FragColor.a = 1.0;
     #endif
 
-    #include <FogFragment>
+    #if ENABLE_FOG == 1
+        #include <FogFragment>
+    #endif    
 
      #ifndef ENGINE_IS_COLORSPACE_GAMMA
         gl_FragColor = linearToGamma(gl_FragColor);

--- a/tests/src/core/material/BlinnPhongMaterial.test.ts
+++ b/tests/src/core/material/BlinnPhongMaterial.test.ts
@@ -3,7 +3,7 @@ import { WebGLEngine } from "@galacean/engine-rhi-webgl";
 import { BlinnPhongMaterial, Texture2D } from "@galacean/engine-core";
 import { expect } from "chai";
 
-describe("BlinnPhongMaterial",  () => {
+describe("BlinnPhongMaterial", () => {
   let engine: WebGLEngine;
   before(async function () {
     engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
@@ -23,6 +23,7 @@ describe("BlinnPhongMaterial",  () => {
     expect(material.normalIntensity).to.eq(1);
     expect(material.shininess).to.eq(16);
     expect(material.tilingOffset).to.deep.eq(new Vector4(1, 1, 0, 0));
+    expect(material.fog).to.eq(true);
 
     material.baseColor.set(1, 0, 0, 1);
     material.specularColor.set(1, 0, 0, 1);
@@ -34,6 +35,7 @@ describe("BlinnPhongMaterial",  () => {
     material.normalIntensity = 2;
     material.shininess = 32;
     material.tilingOffset.set(1, 1, 1, 1);
+    material.fog = false;
 
     expect(material.baseColor).to.deep.eq(new Color(1, 0, 0, 1));
     expect(material.specularColor).to.deep.eq(new Color(1, 0, 0, 1));
@@ -45,6 +47,7 @@ describe("BlinnPhongMaterial",  () => {
     expect(material.normalIntensity).to.eq(2);
     expect(material.shininess).to.eq(32);
     expect(material.tilingOffset).to.deep.eq(new Vector4(1, 1, 1, 1));
+    expect(material.fog).to.eq(false);
 
     material.baseTexture = null;
     material.specularTexture = null;

--- a/tests/src/core/material/PBRMaterial.test.ts
+++ b/tests/src/core/material/PBRMaterial.test.ts
@@ -2,7 +2,7 @@ import { WebGLEngine } from "@galacean/engine-rhi-webgl";
 import { Texture2D, PBRMaterial } from "@galacean/engine-core";
 import { expect } from "chai";
 
-describe("PBRMaterial",  () => {
+describe("PBRMaterial", () => {
   let engine: WebGLEngine;
   before(async function () {
     engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
@@ -15,14 +15,17 @@ describe("PBRMaterial",  () => {
     expect(material.metallic).to.eq(1);
     expect(material.roughness).to.eq(1);
     expect(material.roughnessMetallicTexture).to.be.undefined;
+    expect(material.fog).to.eq(true);
 
     material.metallic = 2;
     material.roughness = 2;
     material.roughnessMetallicTexture = texture;
+    material.fog = false;
 
     expect(material.metallic).to.eq(2);
     expect(material.roughness).to.eq(2);
     expect(material.roughnessMetallicTexture).to.eq(texture);
+    expect(material.fog).to.eq(false);
 
     material.roughnessMetallicTexture = null;
 

--- a/tests/src/core/material/PBRSpecularMaterial.test.ts
+++ b/tests/src/core/material/PBRSpecularMaterial.test.ts
@@ -3,7 +3,7 @@ import { WebGLEngine } from "@galacean/engine-rhi-webgl";
 import { Texture2D, PBRSpecularMaterial } from "@galacean/engine-core";
 import { expect } from "chai";
 
-describe("PBRSpecularMaterial",  () => {
+describe("PBRSpecularMaterial", () => {
   let engine: WebGLEngine;
   before(async function () {
     engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
@@ -16,14 +16,17 @@ describe("PBRSpecularMaterial",  () => {
     expect(material.specularColor).to.deep.eq(new Color(1, 1, 1, 1));
     expect(material.glossiness).to.eq(1);
     expect(material.specularGlossinessTexture).to.be.undefined;
+    expect(material.fog).to.eq(true);
 
     material.specularColor.set(1, 0, 0, 1);
     material.glossiness = 2;
     material.specularGlossinessTexture = texture;
+    material.fog = false;
 
     expect(material.specularColor).to.deep.eq(new Color(1, 0, 0, 1));
     expect(material.glossiness).to.eq(2);
     expect(material.specularGlossinessTexture).to.eq(texture);
+    expect(material.fog).to.eq(false);
 
     material.specularGlossinessTexture = null;
 

--- a/tests/src/core/material/UnlitMaterial.test.ts
+++ b/tests/src/core/material/UnlitMaterial.test.ts
@@ -16,14 +16,17 @@ describe("UnlitMaterial", () => {
     expect(material.baseColor).to.deep.eq(new Color(1, 1, 1, 1));
     expect(material.tilingOffset).to.deep.eq(new Vector4(1, 1, 0, 0));
     expect(material.baseTexture).to.be.undefined;
+    expect(material.fog).to.eq(true);
 
     material.baseColor.set(1, 0, 0, 1);
     material.tilingOffset.set(1, 1, 1, 1);
     material.baseTexture = texture;
+    material.fog = false;
 
     expect(material.baseColor).to.deep.eq(new Color(1, 0, 0, 1));
     expect(material.tilingOffset).to.deep.eq(new Vector4(1, 1, 1, 1));
     expect(material.baseTexture).to.eq(texture);
+    expect(material.fog).to.eq(false);
 
     material.baseTexture = null;
     expect(material.baseTexture).to.be.null;


### PR DESCRIPTION
| disable |  enable |
|---------------------------|---------------------------|
|![enable](https://github.com/galacean/runtime/assets/20318608/8936c802-9b60-47f7-8edb-4fbffa1fec5d) | ![disable](https://github.com/galacean/runtime/assets/20318608/1ac22a4b-bf7a-4966-80d0-4c1181e1cfc3) |

I have read [three.js fog article](https://threejs.org/manual/#en/fog), the last example caught my attention. Seems like `runtime` couldn't achieve this effect. So I propose `fog` property for those materials who could be affected by scene fog.