### PR TITLE
Fix the problem of resetting `HtmlCanvas.ClientXXX` when call `canvas.resizeByClientSize()`

### DIFF
--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -20,8 +20,8 @@ export abstract class Canvas {
   set width(value: number) {
     if (this._width !== value) {
       this._width = value;
+      this._onWidthChanged(value);
       this._sizeUpdateFlagManager.dispatch();
-      this._onSizeChanged(value, this._width);
     }
   }
 
@@ -35,10 +35,12 @@ export abstract class Canvas {
   set height(value: number) {
     if (this._height !== value) {
       this._height = value;
+      this._onHeightChange(value);
       this._sizeUpdateFlagManager.dispatch();
-      this._onSizeChanged(this._width, value);
     }
   }
 
-  protected abstract _onSizeChanged(width: number, height: number): void;
+  protected abstract _onWidthChanged(value: number): void;
+
+  protected abstract _onHeightChange(value: number): void;
 }

--- a/packages/rhi-webgl/src/WebCanvas.ts
+++ b/packages/rhi-webgl/src/WebCanvas.ts
@@ -41,8 +41,10 @@ export class WebCanvas extends Canvas {
   resizeByClientSize(pixelRatio: number = window.devicePixelRatio): void {
     const webCanvas = this._webCanvas;
     if (typeof OffscreenCanvas === "undefined" || !(webCanvas instanceof OffscreenCanvas)) {
-      this.width = webCanvas.clientWidth * pixelRatio;
-      this.height = webCanvas.clientHeight * pixelRatio;
+      const exportWidth = webCanvas.clientWidth * pixelRatio;
+      const exportHeight = webCanvas.clientHeight * pixelRatio;
+      this.width = exportWidth;
+      this.height = exportHeight;
     }
   }
 
@@ -69,8 +71,11 @@ export class WebCanvas extends Canvas {
     this.scale = this._scale;
   }
 
-  protected override _onSizeChanged(width: number, height: number): void {
-    this._webCanvas.width = width;
-    this._webCanvas.height = height;
+  protected override _onWidthChanged(value: number): void {
+    this._webCanvas.width = value;
+  }
+
+  protected override _onHeightChange(value: number): void {
+    this._webCanvas.height = value;
   }
 }


### PR DESCRIPTION
Demo:
```
    <style>
      html,
      body,
      canvas {
        width: 100%;
        /* Deliberately not setting the height */
        /* height: 100%; */
        margin: 0;
        overflow: hidden;
        background: black;
        border: none;
      }
    </style>
```
```
const canvas = document.getElementById("canvas") as HTMLCanvasElement;
console.log("before size", canvas.width, canvas.height);
console.log("before clientSize", canvas.clientWidth, canvas.clientHeight);
canvas.width = canvas.clientWidth * window.devicePixelRatio;
console.log("after size", canvas.width, canvas.height);
console.log("after clientSize", canvas.clientWidth, canvas.clientHeight);
```
output
![image](https://github.com/galacean/runtime/assets/7768919/98fe2f81-0b19-41b7-ae03-821ca14bd3c7)

