### PR TITLE
Fix: particle emission baseShape enabled

### DIFF
--- a/packages/core/src/particle/ParticleGenerator.ts
+++ b/packages/core/src/particle/ParticleGenerator.ts
@@ -226,7 +226,7 @@ export class ParticleGenerator {
       const transform = this._renderer.entity.transform;
       const shape = this.emission.shape;
       for (let i = 0; i < count; i++) {
-        if (shape) {
+        if (shape?.enabled) {
           shape._generatePositionAndDirection(this.emission._shapeRand, time, position, direction);
           const positionScale = this.main._getPositionScale();
           position.multiply(positionScale);

--- a/packages/core/src/particle/modules/shape/BaseShape.ts
+++ b/packages/core/src/particle/modules/shape/BaseShape.ts
@@ -8,7 +8,7 @@ export abstract class BaseShape {
   /** The type of shape to emit particles from. */
   abstract readonly shapeType: ParticleShapeType;
   /** Specifies whether the ShapeModule is enabled or disabled. */
-  enable: boolean = true;
+  enabled: boolean = true;
   /** Randomizes the starting direction of particles. */
   randomDirectionAmount: number = 0;
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
1. old particle emission module baseshape enable won't work
2. change api name to enabled to align with engine api style