### PR TITLE
Fix the problem of resetting `HtmlCanvas.ClientXXX` when call `canvas.resizeByClientSize()`

### DIFF
--- a/packages/core/src/Canvas.ts
+++ b/packages/core/src/Canvas.ts
@@ -20,8 +20,8 @@ export abstract class Canvas {
   set width(value: number) {
     if (this._width !== value) {
       this._width = value;
+      this._onWidthChanged(value);
       this._sizeUpdateFlagManager.dispatch();
-      this._onSizeChanged(value, this._width);
     }
   }
 
@@ -35,10 +35,12 @@ export abstract class Canvas {
   set height(value: number) {
     if (this._height !== value) {
       this._height = value;
+      this._onHeightChange(value);
       this._sizeUpdateFlagManager.dispatch();
-      this._onSizeChanged(this._width, value);
     }
   }
 
-  protected abstract _onSizeChanged(width: number, height: number): void;
+  protected abstract _onWidthChanged(value: number): void;
+
+  protected abstract _onHeightChange(value: number): void;
 }

--- a/packages/rhi-webgl/src/WebCanvas.ts
+++ b/packages/rhi-webgl/src/WebCanvas.ts
@@ -41,8 +41,10 @@ export class WebCanvas extends Canvas {
   resizeByClientSize(pixelRatio: number = window.devicePixelRatio): void {
     const webCanvas = this._webCanvas;
     if (typeof OffscreenCanvas === "undefined" || !(webCanvas instanceof OffscreenCanvas)) {
-      this.width = webCanvas.clientWidth * pixelRatio;
-      this.height = webCanvas.clientHeight * pixelRatio;
+      const exportWidth = webCanvas.clientWidth * pixelRatio;
+      const exportHeight = webCanvas.clientHeight * pixelRatio;
+      this.width = exportWidth;
+      this.height = exportHeight;
     }
   }
 
@@ -69,8 +71,11 @@ export class WebCanvas extends Canvas {
     this.scale = this._scale;
   }
 
-  protected override _onSizeChanged(width: number, height: number): void {
-    this._webCanvas.width = width;
-    this._webCanvas.height = height;
+  protected override _onWidthChanged(value: number): void {
+    this._webCanvas.width = value;
+  }
+
+  protected override _onHeightChange(value: number): void {
+    this._webCanvas.height = value;
   }
 }

--- a/packages/rhi-webgl/src/WebCanvas.ts
+++ b/packages/rhi-webgl/src/WebCanvas.ts
@@ -41,10 +41,8 @@ export class WebCanvas extends Canvas {
   resizeByClientSize(pixelRatio: number = window.devicePixelRatio): void {
     const webCanvas = this._webCanvas;
     if (typeof OffscreenCanvas === "undefined" || !(webCanvas instanceof OffscreenCanvas)) {
-      const exportWidth = webCanvas.clientWidth * pixelRatio;
-      const exportHeight = webCanvas.clientHeight * pixelRatio;
-      this.width = exportWidth;
-      this.height = exportHeight;
+      this.width = webCanvas.clientWidth * pixelRatio;
+      this.height = webCanvas.clientHeight * pixelRatio;
     }
   }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information: