### PR TITLE
fix: `texParameterf` should limit `anisoLevel`

### DIFF
--- a/packages/rhi-webgl/src/GLTexture.ts
+++ b/packages/rhi-webgl/src/GLTexture.ts
@@ -461,7 +461,11 @@ export class GLTexture implements IPlatformTexture {
     const gl = this._gl as WebGLRenderingContext & WebGL2RenderingContext & EXT_texture_filter_anisotropic;
 
     this._bind();
-    gl.texParameterf(this._target, gl.TEXTURE_MAX_ANISOTROPY_EXT, value);
+    gl.texParameterf(
+      this._target,
+      gl.TEXTURE_MAX_ANISOTROPY_EXT,
+      Math.max(1, Math.min(value, this._rhi.capability.maxAnisoLevel))
+    );
   }
 
   set depthCompareFunction(value: TextureDepthCompareFunction) {


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
`texParameterf` should limit `anisoLevel`
