### PR TITLE
Fix`gl.MIN` and `gl.MAX` doesn't exist in `webgl1`

### DIFF
--- a/packages/core/src/shader/state/BlendState.ts
+++ b/packages/core/src/shader/state/BlendState.ts
@@ -49,7 +49,7 @@ export class BlendState {
   }
 
   private static _getGLBlendOperation(rhi: IHardwareRenderer, blendOperation: BlendOperation): number {
-    const { isWebGL2, gl, requireExtension } = rhi;
+    const gl = rhi.gl;
 
     switch (blendOperation) {
       case BlendOperation.Add:
@@ -62,12 +62,12 @@ export class BlendState {
         if (!rhi.canIUse(GLCapabilityType.blendMinMax)) {
           throw new Error("BlendOperation.Min is not supported in this context");
         }
-        return isWebGL2 ? gl.MIN : requireExtension(GLCapabilityType.blendMinMax).MIN_EXT; // in webgl1.0 is an extension
+        return gl.MIN; // in webgl1.0 is an extension
       case BlendOperation.Max:
         if (!rhi.canIUse(GLCapabilityType.blendMinMax)) {
           throw new Error("BlendOperation.Max is not supported in this context");
         }
-        return isWebGL2 ? gl.MAX : requireExtension(GLCapabilityType.blendMinMax).MAX_EXT; // in webgl1.0 is an extension
+        return gl.MAX; // in webgl1.0 is an extension
     }
   }
 

--- a/packages/core/src/shader/state/BlendState.ts
+++ b/packages/core/src/shader/state/BlendState.ts
@@ -49,7 +49,7 @@ export class BlendState {
   }
 
   private static _getGLBlendOperation(rhi: IHardwareRenderer, blendOperation: BlendOperation): number {
-    const gl = rhi.gl;
+    const { isWebGL2, gl, requireExtension } = rhi;
 
     switch (blendOperation) {
       case BlendOperation.Add:
@@ -62,12 +62,12 @@ export class BlendState {
         if (!rhi.canIUse(GLCapabilityType.blendMinMax)) {
           throw new Error("BlendOperation.Min is not supported in this context");
         }
-        return gl.MIN; // in webgl1.0 is an extension
+        return isWebGL2 ? gl.MIN : requireExtension(GLCapabilityType.blendMinMax).MIN_EXT; // in webgl1.0 is an extension
       case BlendOperation.Max:
         if (!rhi.canIUse(GLCapabilityType.blendMinMax)) {
           throw new Error("BlendOperation.Max is not supported in this context");
         }
-        return gl.MAX; // in webgl1.0 is an extension
+        return isWebGL2 ? gl.MAX : requireExtension(GLCapabilityType.blendMinMax).MAX_EXT; // in webgl1.0 is an extension
     }
   }
 

--- a/packages/rhi-webgl/src/GLCapability.ts
+++ b/packages/rhi-webgl/src/GLCapability.ts
@@ -244,11 +244,16 @@ export class GLCapability {
       textureFilterAnisotropic,
       textureHalfFloat,
       colorBufferHalfFloat,
-      WEBGL_colorBufferFloat
+      WEBGL_colorBufferFloat,
+      blendMinMax
     } = GLCapabilityType;
     const { isWebGL2 } = this.rhi;
 
     if (!isWebGL2) {
+      this._compatibleInterface(blendMinMax, {
+        MIN: "MIN_EXT",
+        MAX: "MAX_EXT"
+      });
       this._compatibleInterface(depthTexture, {
         UNSIGNED_INT_24_8: "UNSIGNED_INT_24_8_WEBGL"
       });

--- a/packages/rhi-webgl/src/GLCapability.ts
+++ b/packages/rhi-webgl/src/GLCapability.ts
@@ -154,6 +154,7 @@ export class GLCapability {
       instancedArrays,
       multipleSample,
       drawBuffers,
+      blendMinMax,
 
       astc,
       astc_webkit,
@@ -185,6 +186,7 @@ export class GLCapability {
     cap.set(instancedArrays, isWebGL2 || !!requireExtension(instancedArrays));
     cap.set(multipleSample, isWebGL2);
     cap.set(drawBuffers, isWebGL2 || !!requireExtension(drawBuffers));
+    cap.set(blendMinMax, isWebGL2 || !!requireExtension(blendMinMax));
     cap.set(textureFloat, isWebGL2 || !!requireExtension(textureFloat));
     cap.set(textureHalfFloat, isWebGL2 || !!requireExtension(textureHalfFloat));
     cap.set(textureFloatLinear, !!requireExtension(textureFloatLinear));


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
[EXT_blend_minmax](https://developer.mozilla.org/en-US/docs/Web/API/EXT_blend_minmax)
![image](https://github.com/galacean/runtime/assets/20318608/640266b5-3edf-4987-abb8-bf9fcf8abd44)