### PR TITLE
Texture support `R32G32B32A32_UInt` format

### DIFF
--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -46,7 +46,7 @@ import { ColorWriteMask } from "./shader/enums/ColorWriteMask";
 import { CullMode } from "./shader/enums/CullMode";
 import { RenderQueueType } from "./shader/enums/RenderQueueType";
 import { RenderState } from "./shader/state/RenderState";
-import { Texture2D, Texture2DArray, TextureCube, TextureCubeFace, TextureFormat } from "./texture";
+import { Texture2D, Texture2DArray, TextureCube, TextureCubeFace, TextureFilterMode, TextureFormat } from "./texture";
 import { XRManager } from "./xr/XRManager";
 
 ShaderPool.init();
@@ -106,6 +106,8 @@ export class Engine extends EventDispatcher {
   _whiteTexture2D: Texture2D;
   /* @internal */
   _magentaTexture2D: Texture2D;
+  /* @internal */
+  _uintMagentaTexture2D: Texture2D;
   /* @internal */
   _magentaTextureCube: TextureCube;
   /* @internal */
@@ -601,6 +603,11 @@ export class Engine extends EventDispatcher {
     this._magentaTextureCube = magentaTextureCube;
 
     if (hardwareRenderer.isWebGL2) {
+      const magentaPixel32 = new Uint32Array([255, 0, 255, 255]);
+      const uintMagentaTexture2D = new Texture2D(this, 1, 1, TextureFormat.R32G32B32A32_UInt, false);
+      uintMagentaTexture2D.setPixelBuffer(magentaPixel32);
+      uintMagentaTexture2D.isGCIgnored = true;
+
       const magentaTexture2DArray = new Texture2DArray(this, 1, 1, 1, TextureFormat.R8G8B8A8, false);
       magentaTexture2DArray.setPixelBuffer(0, magentaPixel);
       magentaTexture2DArray.isGCIgnored = true;
@@ -614,6 +621,8 @@ export class Engine extends EventDispatcher {
           }
         })()
       );
+
+      this._uintMagentaTexture2D = uintMagentaTexture2D;
       this._magentaTexture2DArray = magentaTexture2DArray;
     }
   }

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -46,7 +46,7 @@ import { ColorWriteMask } from "./shader/enums/ColorWriteMask";
 import { CullMode } from "./shader/enums/CullMode";
 import { RenderQueueType } from "./shader/enums/RenderQueueType";
 import { RenderState } from "./shader/state/RenderState";
-import { Texture2D, Texture2DArray, TextureCube, TextureCubeFace, TextureFilterMode, TextureFormat } from "./texture";
+import { Texture2D, Texture2DArray, TextureCube, TextureCubeFace, TextureFormat } from "./texture";
 import { XRManager } from "./xr/XRManager";
 
 ShaderPool.init();
@@ -607,6 +607,16 @@ export class Engine extends EventDispatcher {
       const uintMagentaTexture2D = new Texture2D(this, 1, 1, TextureFormat.R32G32B32A32_UInt, false);
       uintMagentaTexture2D.setPixelBuffer(magentaPixel32);
       uintMagentaTexture2D.isGCIgnored = true;
+      this.resourceManager.addContentRestorer(
+        new (class extends ContentRestorer<Texture2D> {
+          constructor() {
+            super(uintMagentaTexture2D);
+          }
+          restoreContent() {
+            this.resource.setPixelBuffer(magentaPixel32);
+          }
+        })()
+      );
 
       const magentaTexture2DArray = new Texture2DArray(this, 1, 1, 1, TextureFormat.R8G8B8A8, false);
       magentaTexture2DArray.setPixelBuffer(0, magentaPixel);

--- a/packages/core/src/shader/ShaderProgram.ts
+++ b/packages/core/src/shader/ShaderProgram.ts
@@ -1,17 +1,17 @@
 import { IHardwareRenderer } from "@galacean/engine-design";
 import { Vector2, Vector3, Vector4 } from "@galacean/engine-math";
-import { Logger } from "../base/Logger";
 import { Camera } from "../Camera";
 import { Engine } from "../Engine";
-import { Material } from "../material/Material";
 import { Renderer } from "../Renderer";
 import { Scene } from "../Scene";
+import { Logger } from "../base/Logger";
+import { Material } from "../material/Material";
 import { Texture } from "../texture";
-import { ShaderDataGroup } from "./enums/ShaderDataGroup";
 import { ShaderData } from "./ShaderData";
 import { ShaderProperty } from "./ShaderProperty";
 import { ShaderUniform } from "./ShaderUniform";
 import { ShaderUniformBlock } from "./ShaderUniformBlock";
+import { ShaderDataGroup } from "./enums/ShaderDataGroup";
 
 /**
  * Shader program, corresponding to the GPU shader program.
@@ -400,6 +400,7 @@ export class ShaderProgram {
           break;
         case gl.SAMPLER_2D:
         case gl.SAMPLER_CUBE:
+        case (<WebGL2RenderingContext>gl).UNSIGNED_INT_SAMPLER_2D:
         case (<WebGL2RenderingContext>gl).SAMPLER_2D_ARRAY:
         case (<WebGL2RenderingContext>gl).SAMPLER_2D_SHADOW:
           let defaultTexture: Texture;
@@ -409,6 +410,9 @@ export class ShaderProgram {
               break;
             case gl.SAMPLER_CUBE:
               defaultTexture = this._engine._magentaTextureCube;
+              break;
+            case (<WebGL2RenderingContext>gl).UNSIGNED_INT_SAMPLER_2D:
+              defaultTexture = this._engine._uintMagentaTexture2D;
               break;
             case (<WebGL2RenderingContext>gl).SAMPLER_2D_ARRAY:
               defaultTexture = this._engine._magentaTexture2DArray;

--- a/packages/core/src/texture/Texture.ts
+++ b/packages/core/src/texture/Texture.ts
@@ -106,7 +106,8 @@ export abstract class Texture extends GraphicsResource {
   set filterMode(value: TextureFilterMode) {
     if (value === this._filterMode) return;
 
-    if (this._isIntFormat() && value !== TextureFilterMode.Point) {
+    if (value !== TextureFilterMode.Point && this._isIntFormat()) {
+      value = TextureFilterMode.Point;
       Logger.warn(`TextureFilterMode of int or uint format only support TextureFilterMode.Point`);
       return;
     }

--- a/packages/core/src/texture/Texture.ts
+++ b/packages/core/src/texture/Texture.ts
@@ -105,6 +105,12 @@ export abstract class Texture extends GraphicsResource {
 
   set filterMode(value: TextureFilterMode) {
     if (value === this._filterMode) return;
+
+    if (this._isIntFormat() && value !== TextureFilterMode.Point) {
+      Logger.warn(`TextureFilterMode of int or uint format only support TextureFilterMode.Point`);
+      return;
+    }
+
     this._filterMode = value;
 
     this._platformTexture.filterMode = value;
@@ -210,5 +216,12 @@ export abstract class Texture extends GraphicsResource {
 
   protected _getMipmapCount(): number {
     return this._mipmap ? Math.floor(Math.log2(Math.max(this._width, this._height))) + 1 : 1;
+  }
+
+  protected _isIntFormat(): boolean {
+    if (TextureFormat.R32G32B32A32_UInt === this._format) {
+      return true;
+    }
+    return false;
   }
 }

--- a/packages/core/src/texture/Texture.ts
+++ b/packages/core/src/texture/Texture.ts
@@ -108,7 +108,7 @@ export abstract class Texture extends GraphicsResource {
 
     if (value !== TextureFilterMode.Point && this._isIntFormat()) {
       value = TextureFilterMode.Point;
-      Logger.warn(`TextureFilterMode of int or uint format only support TextureFilterMode.Point`);
+      Logger.warn(`Int or UInt format texture only support TextureFilterMode.Point`);
       return;
     }
 

--- a/packages/core/src/texture/Texture2D.ts
+++ b/packages/core/src/texture/Texture2D.ts
@@ -46,7 +46,7 @@ export class Texture2D extends Texture {
 
     this._platformTexture = engine._hardwareRenderer.createPlatformTexture2D(this);
 
-    this.filterMode = TextureFilterMode.Bilinear;
+    this.filterMode = TextureFormat.R32G32B32A32_UInt ? TextureFilterMode.Point : TextureFilterMode.Bilinear;
     this.wrapModeU = this.wrapModeV = TextureWrapMode.Repeat;
   }
 

--- a/packages/core/src/texture/Texture2D.ts
+++ b/packages/core/src/texture/Texture2D.ts
@@ -46,7 +46,7 @@ export class Texture2D extends Texture {
 
     this._platformTexture = engine._hardwareRenderer.createPlatformTexture2D(this);
 
-    this.filterMode = TextureFormat.R32G32B32A32_UInt ? TextureFilterMode.Point : TextureFilterMode.Bilinear;
+    this.filterMode = this._isIntFormat() ? TextureFilterMode.Point : TextureFilterMode.Bilinear;
     this.wrapModeU = this.wrapModeV = TextureWrapMode.Repeat;
   }
 

--- a/packages/core/src/texture/enums/TextureFormat.ts
+++ b/packages/core/src/texture/enums/TextureFormat.ts
@@ -20,6 +20,8 @@ export enum TextureFormat {
   R16G16B16A16,
   /** RGBA format, 32 bits per channel. */
   R32G32B32A32,
+  /** RGBA unsigned integer format, 32 bits per channel. */
+  R32G32B32A32_UInt,
 
   /** RGB compressed format, 4 bits per pixel. */
   BC1,

--- a/packages/rhi-webgl/src/GLTexture.ts
+++ b/packages/rhi-webgl/src/GLTexture.ts
@@ -96,6 +96,13 @@ export class GLTexture implements IPlatformTexture {
           dataType: gl.FLOAT,
           isCompressed: false
         };
+      case TextureFormat.R32G32B32A32_UInt:
+        return {
+          internalFormat: isWebGL2 ? gl.RGBA32UI : gl.NONE,
+          baseFormat: gl.RGBA_INTEGER,
+          dataType: gl.UNSIGNED_INT,
+          isCompressed: false
+        };
       case TextureFormat.BC1:
         return {
           internalFormat: GLCompressedTextureInternalFormat.RGB_S3TC_DXT1_EXT,
@@ -347,6 +354,7 @@ export class GLTexture implements IPlatformTexture {
           return false;
         }
         break;
+      case TextureFormat.R32G32B32A32_UInt:
       case TextureFormat.Depth24:
       case TextureFormat.Depth32:
       case TextureFormat.Depth32Stencil8:

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -32,7 +32,7 @@ describe("ResourceManager", () => {
   describe("findResourcesByType", () => {
     it("findResourcesByType", () => {
       const textures = engine.resourceManager.findResourcesByType(Texture2D);
-      expect(textures.length).equal(4);
+      expect(textures.length).equal(5);
     });
   });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Example:

Create texture:
```ts
  const magentaPixel32 = new Uint32Array([255, 0, 255, 255]);
  const uintMagentaTexture2D = new Texture2D(this, 1, 1, TextureFormat.R32G32B32A32_UInt, false);
  uintMagentaTexture2D.setPixelBuffer(magentaPixel32);
```

Shader:
```glsl
  uniform highp usampler2D u_uintTetxure;
  
  void main() {
    uvec4 texel = texture2D(u_uintTetxure, v_uv);

    gl_FragColor = vec4(texel);
  }
```