### PR TITLE
Fix gltf accessor's bufferView could be undefined

### DIFF
--- a/packages/loader/src/gltf/GLTFUtils.ts
+++ b/packages/loader/src/gltf/GLTFUtils.ts
@@ -134,7 +134,8 @@ export class GLTFUtils {
     accessor: IAccessor
   ): Promise<BufferInfo> {
     const componentType = accessor.componentType;
-    const bufferView = bufferViews[accessor.bufferView ?? 0];
+    const bufferViewIndex = accessor.bufferView ?? 0;
+    const bufferView = bufferViews[bufferViewIndex];
 
     return context.get<ArrayBuffer>(GLTFParserType.Buffer).then((buffers) => {
       const bufferIndex = bufferView.buffer;
@@ -153,7 +154,7 @@ export class GLTFUtils {
       // According to the glTF official documentation only byteStride not undefined is allowed
       if (bufferStride !== undefined && bufferStride !== elementStride) {
         const bufferSlice = Math.floor(byteOffset / bufferStride);
-        const bufferCacheKey = accessor.bufferView + ":" + componentType + ":" + bufferSlice + ":" + accessorCount;
+        const bufferCacheKey = bufferViewIndex + ":" + componentType + ":" + bufferSlice + ":" + accessorCount;
         const accessorBufferCache = context.accessorBufferCache;
         bufferInfo = accessorBufferCache[bufferCacheKey];
         if (!bufferInfo) {
@@ -206,7 +207,7 @@ export class GLTFUtils {
    */
   static getAccessorData(glTF: IGLTF, accessor: IAccessor, buffers: ArrayBuffer[]): TypedArray {
     const bufferViews = glTF.bufferViews;
-    const bufferView = bufferViews[accessor.bufferView];
+    const bufferView = bufferViews[accessor.bufferView ?? 0];
     const arrayBuffer = buffers[bufferView.buffer];
     const accessorByteOffset = accessor.hasOwnProperty("byteOffset") ? accessor.byteOffset : 0;
     const bufferViewByteOffset = bufferView.hasOwnProperty("byteOffset") ? bufferView.byteOffset : 0;

--- a/packages/loader/src/gltf/GLTFUtils.ts
+++ b/packages/loader/src/gltf/GLTFUtils.ts
@@ -134,7 +134,7 @@ export class GLTFUtils {
     accessor: IAccessor
   ): Promise<BufferInfo> {
     const componentType = accessor.componentType;
-    const bufferView = bufferViews[accessor.bufferView];
+    const bufferView = bufferViews[accessor.bufferView ?? 0];
 
     return context.get<ArrayBuffer>(GLTFParserType.Buffer).then((buffers) => {
       const bufferIndex = bufferView.buffer;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

follow the instruction of standard of gltf: https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/accessor.schema.json#L12C13-L12C212

The `bufferView` field of accessor could be `undefined`. We should use `0` instead of `undefined`.