### PR TITLE
Fix error when destroying `SkinnedRenderer`

### DIFF
--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -235,7 +235,6 @@ export class SkinnedMeshRenderer extends MeshRenderer {
    */
   override _onDestroy(): void {
     super._onDestroy();
-    this._unRegisterEntityTransformListener();
     this._rootBone = null;
     this._jointDataCreateCache = null;
     this._skin = null;


### PR DESCRIPTION
If your `SkinnedRenderer` does not have a `rootBone`, an error will be reported when it is destroyed. This error was introduced by [PR](https://github.com/galacean/runtime/pull/2015).