### PR TITLE
Fix `pass.renderstate` does not work in `SpriteRenderer`

### DIFF
--- a/packages/core/src/2d/sprite/SpriteMask.ts
+++ b/packages/core/src/2d/sprite/SpriteMask.ts
@@ -204,6 +204,16 @@ export class SpriteMask extends Renderer {
       return;
     }
 
+    let material = this.getMaterial();
+    if (!material) {
+      return;
+    }
+    const { _engine: engine } = this;
+    // @todo: This question needs to be raised rather than hidden.
+    if (material.destroyed) {
+      material = engine._spriteMaskDefaultMaterial;
+    }
+
     // Update position
     if (this._dirtyUpdateFlag & RendererUpdateFlags.WorldVolume) {
       SimpleSpriteAssembler.updatePositions(this);
@@ -218,11 +228,10 @@ export class SpriteMask extends Renderer {
 
     context.camera._renderPipeline._allSpriteMasks.add(this);
 
-    const renderData = this._engine._spriteMaskRenderDataPool.getFromPool();
-    const material = this.getMaterial();
+    const renderData = engine._spriteMaskRenderDataPool.getFromPool();
     renderData.set(this, material, this._verticesData);
 
-    const renderElement = this._engine._renderElementPool.getFromPool();
+    const renderElement = engine._renderElementPool.getFromPool();
     renderElement.set(renderData, material.shader.subShaders[0].passes);
     this._maskElement = renderElement;
   }

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -308,6 +308,12 @@ export class SpriteRenderer extends Renderer {
       return;
     }
 
+    // @todo: Check if `Renderer` is renderable before culling
+    const material = this.getMaterial();
+    if (!material) {
+      return;
+    }
+
     // Update position
     if (this._dirtyUpdateFlag & RendererUpdateFlags.WorldVolume) {
       this._assembler.updatePositions(this);
@@ -321,7 +327,6 @@ export class SpriteRenderer extends Renderer {
     }
 
     // Push primitive
-    const material = this.getMaterial();
     const texture = this.sprite.texture;
     const renderData = this._engine._spriteRenderDataPool.getFromPool();
     renderData.set(this, material, this._verticesData, texture);

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -308,10 +308,13 @@ export class SpriteRenderer extends Renderer {
       return;
     }
 
-    // @todo: Check if `Renderer` is renderable before culling
-    const material = this.getMaterial();
+    let material = this.getMaterial();
     if (!material) {
       return;
+    }
+    // @todo: This question needs to be raised rather than hidden.
+    if (material.destroyed) {
+      material = this._engine._spriteDefaultMaterials[this._maskInteraction];
     }
 
     // Update position

--- a/packages/core/src/RenderPipeline/SpriteBatcher.ts
+++ b/packages/core/src/RenderPipeline/SpriteBatcher.ts
@@ -110,8 +110,8 @@ export class SpriteBatcher extends Basic2DBatcher {
         compileMacros
       );
 
-      const shaderPass = spriteElement.shaderPasses[0];
-      const program = shaderPass._getShaderProgram(engine, compileMacros);
+      const pass = spriteElement.shaderPasses[0];
+      const program = pass._getShaderProgram(engine, compileMacros);
       if (!program.isValid) {
         return;
       }
@@ -125,7 +125,7 @@ export class SpriteBatcher extends Basic2DBatcher {
       program.uploadAll(program.rendererUniformBlock, renderer.shaderData);
       program.uploadAll(program.materialUniformBlock, material.shaderData);
 
-      material.renderState._apply(engine, false, shaderPass._renderStateDataMap, material.shaderData);
+      (pass._renderState || material.renderState)._apply(engine, false, pass._renderStateDataMap, material.shaderData);
       engine._hardwareRenderer.drawPrimitive(primitive, subMesh, program);
 
       maskManager.postRender(renderer);

--- a/packages/core/src/RenderPipeline/SpriteMaskBatcher.ts
+++ b/packages/core/src/RenderPipeline/SpriteMaskBatcher.ts
@@ -97,7 +97,7 @@ export class SpriteMaskBatcher extends Basic2DBatcher {
       program.uploadAll(program.rendererUniformBlock, renderer.shaderData);
       program.uploadAll(program.materialUniformBlock, material.shaderData);
 
-      material.renderState._apply(engine, false, pass._renderStateDataMap, material.shaderData);
+      (pass._renderState || material.renderState)._apply(engine, false, pass._renderStateDataMap, material.shaderData);
 
       engine._hardwareRenderer.drawPrimitive(primitive, subMesh, program);
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

```typescript
/**
 * @title ShaderLab 2D
 * @category Material
 */

import {
  AssetType,
  Camera,
  Material,
  Shader,
  Sprite,
  SpriteRenderer,
  Texture2D,
  WebGLEngine,
} from "@galacean/engine";
import { ShaderLab } from "@galacean/engine-shader-lab";

const shaderLab = new ShaderLab();

const test2d = `Shader "test2d" {
    SubShader "Default" {
      Pass "Pass0" {
        mat4 renderer_MVPMat;
        sampler2D renderer_SpriteTexture;
  
        DepthState {
          Enabled = true;
          WriteEnabled = false;
          CompareFunction = CompareFunction.Less;
        }
  
        StencilState {
          Enabled = false;
        }
  
        RasterState {
          CullMode = CullMode.Off;
        }
  
        BlendState {
          Enabled = true;
          SourceColorBlendFactor = BlendFactor.SourceAlpha;
          DestinationColorBlendFactor = BlendFactor.OneMinusSourceAlpha;
          SourceAlphaBlendFactor = BlendFactor.One;
          DestinationAlphaBlendFactor = BlendFactor.OneMinusSourceAlpha;
          ColorBlendOperation = BlendOperation.Add;
          AlphaBlendOperation = BlendOperation.Add;
        }
        
        RenderQueueType = RenderQueueType.Transparent;
  
        struct a2v {
          vec4 POSITION;
          vec2 TEXCOORD_0;
          vec4 COLOR_0;
        }
  
        struct v2f {
          vec4 v_color;
          vec2 v_uv;
        }
  
        VertexShader = vert;
        FragmentShader = frag;
  
        v2f vert(a2v v) {
          v2f o;
  
          gl_Position = renderer_MVPMat * v.POSITION;
          o.v_color = v.COLOR_0;
          o.v_uv = v.TEXCOORD_0;
          return o;
        }
  
        void frag(v2f i) {
          vec4 baseColor = texture2D(renderer_SpriteTexture, i.v_uv);
          gl_FragColor = baseColor * i.v_color;
        //   gl_FragColor = vec4(1, 0, 0, 0.1);
        }
      }
    }
  }`;

WebGLEngine.create({ canvas: "canvas", shaderLab }).then((engine) => {
  Shader.create(test2d);
  engine.canvas.resizeByClientSize();
  const rootEntity = engine.sceneManager.activeScene.createRootEntity();

  // camera
  const cameraEntity = rootEntity.createChild("cameraNode");
  cameraEntity.transform.setPosition(0, 0, 5);
  cameraEntity.addComponent(Camera);

  engine.resourceManager
    .load<Texture2D>({
      url: "https://gw.alipayobjects.com/mdn/rms_7c464e/afts/img/A*ApFPTZSqcMkAAAAAAAAAAAAAARQnAQ",
      type: AssetType.Texture2D,
    })
    .then((texture) => {
      const entity = rootEntity.createChild("sprite");
      const renderer = entity.addComponent(SpriteRenderer);
      renderer.sprite = new Sprite(engine, texture);
      renderer.setMaterial(new Material(engine, Shader.find("test2d")));
    });

  engine.run();
});
```