### PR TITLE
Fix compiling error introduced by preprocessor

### DIFF
--- a/packages/shader-lab/src/Ast2GLSLUtils.ts
+++ b/packages/shader-lab/src/Ast2GLSLUtils.ts
@@ -102,9 +102,9 @@ export class Ast2GLSLUtils {
       }
     });
 
-    // There may be global variable references in conditional macro statement, so it needs to be serialized first.
-    const conditionalMacroText = context.getGlobalMacroText(passAst.content.conditionalMacros);
     const vertexFnStr = vertFnAst.serialize(context);
+    // There may be global variable references in conditional macro statement, so it needs to be serialized right after main function.
+    const conditionalMacroText = context.getGlobalMacroText(passAst.content.conditionalMacros);
 
     const globalFragmentSource = [
       ...context.getGlobalMacroText(passAst.content.macros),

--- a/packages/shader-lab/src/ast-node/AstNode.ts
+++ b/packages/shader-lab/src/ast-node/AstNode.ts
@@ -266,7 +266,7 @@ export class FnMacroDefineAstNode extends AstNode<IFnMacroDefineAstContent> {
   override _doSerialization(context?: RuntimeContext, args?: any): string {
     if (context?.currentMainFnAst) context.referenceGlobal(this.content.variable.getVariableName());
     return `#define ${this.content.variable.serialize(context)} ${
-      this.content.value?.serialize(context, { skipUniform: true }) ?? ""
+      this.content.value?.serialize(context, { skipUniform: true, skipComma: true }) ?? ""
     }`;
   }
 
@@ -789,7 +789,7 @@ export class VariableTypeAstNode extends AstNode<IVariableTypeAstContent> {
 
 export class VariableDeclarationAstNode extends AstNode<IFnVariableDeclarationAstContent> {
   override _astType: string = "VariableDeclaration";
-  override _doSerialization(context: RuntimeContext, opts?: { skipUniform: boolean }): string {
+  override _doSerialization(context: RuntimeContext, opts?: { skipUniform: boolean; skipComma: boolean }): string {
     if (context.currentFunctionInfo) {
       context.currentFunctionInfo.localDeclaration.push(this);
     }
@@ -820,7 +820,7 @@ export class VariableDeclarationAstNode extends AstNode<IFnVariableDeclarationAs
       ret = "uniform " + ret;
     }
 
-    return ret + ";";
+    return opts?.skipComma ? ret : ret + ";";
   }
 }
 

--- a/packages/shader-lab/src/preprocessor/Preprocessor.ts
+++ b/packages/shader-lab/src/preprocessor/Preprocessor.ts
@@ -77,6 +77,11 @@ export class Preprocessor {
     while (true) {
       const result = tokenizer.scanToken();
       const { end, res: token } = result;
+      if (tokenizer.curChar === "/" && tokenizer.peek === "/") {
+        // ignore comments
+        tokenizer.scanChunk("\n");
+        continue;
+      }
       if (token) {
         const defineMacro = this._definePairs.get(token.text);
         if (defineMacro && this._curMacroLvl === 0) {

--- a/packages/shader-lab/src/preprocessor/Tokenizer.ts
+++ b/packages/shader-lab/src/preprocessor/Tokenizer.ts
@@ -20,6 +20,10 @@ export class Tokenizer {
     return this._text[this._posTicker.index];
   }
 
+  get peek() {
+    return this._text[this._posTicker.index + 1];
+  }
+
   get curIndex() {
     return this._posTicker.index;
   }

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -250,4 +250,9 @@ describe("ShaderLab", () => {
     const shaderSource = fs.readFileSync(path.join(__dirname, "shaders/multi-pass.shader")).toString();
     glslValidate(shaderSource, shaderLab);
   });
+
+  it("macro-with-preprocessor", () => {
+    const shaderSource = fs.readFileSync(path.join(__dirname, "shaders/macro-pre.shader")).toString();
+    glslValidate(shaderSource, shaderLab);
+  });
 });

--- a/tests/src/shader-lab/shaders/macro-pre.shader
+++ b/tests/src/shader-lab/shaders/macro-pre.shader
@@ -1,0 +1,149 @@
+Shader "Water" {
+
+  DepthState depthState {
+    Enabled = true;
+    WriteEnabled = false;
+    CompareFunction = CompareFunction.Greater;
+  }
+
+  RasterState rasterState {
+    CullMode = CullMode.Front;
+    DepthBias = 0.1;
+    SlopeScaledDepthBias = 0.8;
+  }
+
+  SubShader "subname" {
+    Tags { LightMode = "ForwardBase", Tag2 = true, Tag3 = 1.2 }
+
+    BlendFactor material_SrcBlend;
+
+    BlendState blendState {
+      SourceAlphaBlendFactor = material_SrcBlend;
+      Enabled[0] = true;
+      ColorWriteMask[0] = 0.8;
+      BlendColor = vec4(1.0, 1.0, 1.0, 1.0);
+      AlphaBlendOperation = BlendOperation.Max;
+    }
+
+    UsePass "pbr/Default/Forward"
+
+    Pass "default" {
+      Tags { ReplacementTag = "Opaque", Tag2 = true, Tag3 = 1.9 }
+
+      struct a2v {
+       vec4 POSITION;
+       vec2 TEXCOORD_0; 
+      }
+
+      struct v2f {
+       vec2 v_uv;
+       vec3 v_position;
+      }
+
+      mat4 renderer_MVPMat;
+      mat4 renderer_MVMat;
+
+      sampler2D material_BaseTexture;
+      vec4 u_color;
+      vec4 u_fogColor;
+      float u_fogDensity;
+      
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      vec4 linearToGamma(vec4 linearIn) {
+          return vec4(pow(linearIn.rgb, vec3(1.0 / 2.2)), linearIn.a);
+    }
+
+    BlendState = blendState;
+
+    StencilState {
+      Enabled = true;
+      ReferenceValue = 2;
+      Mask = 1.3; // 0xffffffff
+      WriteMask = 0.32; // 0xffffffff
+      CompareFunctionFront = CompareFunction.Less;
+      PassOperationBack = StencilOperation.Zero;
+    }
+
+    DepthState = depthState;
+    RasterState = rasterState;
+
+    #define SCENE_SHADOW_TYPE 3
+
+    #if defined(SCENE_SHADOW_TYPE) && defined(RENDERER_IS_RECEIVE_SHADOWS)
+    #define SCENE_IS_CALCULATE_SHADOWS
+#endif
+
+#define xxx
+#ifdef xxx
+
+mediump sampler2DShadow scene_ShadowMap;
+#define SAMPLE_TEXTURE2D_SHADOW(textureName, coord3) textureLod(textureName, coord3 , 0.0)
+#define TEXTURE2D_SHADOW_PARAM(shadowMap) mediump sampler2DShadow shadowMap
+
+#endif
+
+float sampleShadowMapFiltered4(TEXTURE2D_SHADOW_PARAM(shadowMap), vec3 shadowCoord, vec4 shadowMapSize) {
+    float attenuation;
+    vec4 attenuation4;
+    vec2 offset=shadowMapSize.xy/2.0;
+    vec3 shadowCoord0=shadowCoord + vec3(-offset,0.0);
+    vec3 shadowCoord1=shadowCoord + vec3(offset.x,-offset.y,0.0);
+    vec3 shadowCoord2=shadowCoord + vec3(-offset.x,offset.y,0.0);
+    vec3 shadowCoord3=shadowCoord + vec3(offset,0.0);
+    attenuation4.x = SAMPLE_TEXTURE2D_SHADOW(shadowMap, shadowCoord0);
+    attenuation4.y = SAMPLE_TEXTURE2D_SHADOW(shadowMap, shadowCoord1);
+    attenuation4.z = SAMPLE_TEXTURE2D_SHADOW(shadowMap, shadowCoord2);
+    attenuation4.w = SAMPLE_TEXTURE2D_SHADOW(shadowMap, shadowCoord3);
+    attenuation = dot(attenuation4, vec4(0.25));
+    return attenuation;
+}
+
+      v2f vert(a2v v) {
+        v2f o;
+
+        o.v_uv = v.TEXCOORD_0;
+        vec4 tmp = renderer_MVMat * POSITION;
+        float t = sampleShadowMapFiltered4(scene_ShadowMap, vec3(1.0), vec4(1.0));
+        o.v_position = tmp.xyz;
+        gl_Position = renderer_MVPMat * v.POSITION;
+        return o;
+      }
+
+      void frag(v2f i) {
+        vec4 color = texture2D(material_BaseTexture, i.v_uv) * u_color;
+        float fogDistance = length(i.v_position);
+        float fogAmount = 1.0 - exp2(-u_fogDensity * u_fogDensity * fogDistance * fogDistance * 1.442695);
+        fogAmount = clamp(fogAmount, 0.0, 1.0);
+        gl_FragColor = mix(color, u_fogColor, fogAmount); 
+  
+        #ifndef ENGINE_IS_COLORSPACE_GAMMA
+          gl_FragColor = linearToGamma(gl_FragColor);
+        #endif
+
+        // For testing only (macro)
+        #if SCENE_SHADOW_TYPE == 2 || defined(XX_Macro)
+          gl_FragColor = linearToGamma(gl_FragColor);
+        #elif SCENE_SHADOW_TYPE == 3
+          gl_FragColor = linearToGamma(gl_FragColor);
+        #else 
+          gl_FragColor = vec4(1.0, 1.0, 0.0, 0.0);
+        #endif
+
+        #undef SCENE_SHADOW_TYPE
+
+        #ifndef SCENE_SHADOW_TYPE
+          gl_FragColor = linearToGamma(gl_FragColor);
+        #else
+          gl_FragColor = vec4(1.0, 1.0, 0.0, 0.0);
+        #endif 
+
+        #ifdef SCENE_SHADOW_TYPE
+          gl_FragColor = vec4(1.0, 1.0, 0.0, 0.0);
+        #endif 
+      }
+    }
+    UsePass "blinn-phong/Default/Forward"
+  }
+}

--- a/tests/src/shader-lab/test-case/compare/frag.txt
+++ b/tests/src/shader-lab/test-case/compare/frag.txt
@@ -2,6 +2,8 @@
 #define SCENE_IS_CALCULATE_SHADOWS
 #endif
 
+// #include "ShadowCoord"
+
 // comments
 
 

--- a/tests/src/shader-lab/test-case/compare/frag.txt
+++ b/tests/src/shader-lab/test-case/compare/frag.txt
@@ -4,15 +4,16 @@
 
 // comments
 
+
 vec4 a = vec4(1.0,1.0,3.0,4.0);
 
 
 
 #ifdef SCENE_IS_CALCULATE_SHADOWS
-#if SCENE_SHADOW_CASCADED_COUNT == 1
-    varying vec3 v_shadowCoord;
-#else
-    
+    #if SCENE_SHADOW_CASCADED_COUNT == 1
+        varying vec3 v_shadowCoord;
+    #else
+        
 uniform mat4 scene_ShadowMatrices[SCENE_SHADOW_CASCADED_COUNT+1];uniform vec4 scene_ShadowSplitSpheres[4];mediump int computeCascadeIndex(vec3 positionWS){vec3 fromCenter0=positionWS-scene_ShadowSplitSpheres[0].xyz;vec3 fromCenter1=positionWS-scene_ShadowSplitSpheres[1].xyz;vec3 fromCenter2=positionWS-scene_ShadowSplitSpheres[2].xyz;vec3 fromCenter3=positionWS-scene_ShadowSplitSpheres[3].xyz;mediump vec4 comparison=vec4(dot(fromCenter0,fromCenter0)<scene_ShadowSplitSpheres[0].w,dot(fromCenter1,fromCenter1)<scene_ShadowSplitSpheres[1].w,dot(fromCenter2,fromCenter2)<scene_ShadowSplitSpheres[2].w,dot(fromCenter3,fromCenter3)<scene_ShadowSplitSpheres[3].w);comparison.yzw=clamp(comparison.yzw-comparison.xyz,0.0,1.0);mediump vec4 indexCoefficient=vec4(4.0,3.0,2.0,1.0);mediump int index=4-int(dot(comparison,indexCoefficient));return index;}vec3 getShadowCoord(){
 #if SCENE_SHADOW_CASCADED_COUNT == 1
 mediump int cascadeIndex=0;
@@ -34,6 +35,7 @@ if(cascadeIndex==0){shadowMatrix=scene_ShadowMatrices[0];}else{shadowMatrix=scen
 #endif
 #endif
 vec4 shadowCoord=shadowMatrix*vec4(v_pos,1.0);return shadowCoord.xyz;}
+    #endif
 #endif
 float a = 1.0;
 float b = 2.0;

--- a/tests/src/shader-lab/test-case/source/frag.txt
+++ b/tests/src/shader-lab/test-case/source/frag.txt
@@ -2,6 +2,8 @@
 #define SCENE_IS_CALCULATE_SHADOWS
 #endif
 
+// #include "ShadowCoord"
+
 #define TT 1.0 // comments
 #define QQ
 

--- a/tests/src/shader-lab/test-case/source/frag.txt
+++ b/tests/src/shader-lab/test-case/source/frag.txt
@@ -10,10 +10,11 @@ vec4 a = vec4(TT,1.0,3.0,4.0);
 #define min(X, Y)  ((X) < (Y) ? (TT) : (Y))
 
 #ifdef SCENE_IS_CALCULATE_SHADOWS
-#if SCENE_SHADOW_CASCADED_COUNT == 1
-    varying vec3 v_shadowCoord;
-#else
-    #include "ShadowCoord"
+    #if SCENE_SHADOW_CASCADED_COUNT == 1
+        varying vec3 v_shadowCoord;
+    #else
+        #include "ShadowCoord"
+    #endif
 #endif
 float a = 1.0;
 float b = 2.0;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

1. Fix compiling to GLSL error when exist global function contained in a macro and the function implementation include varying struct property access
2. Fix compiling to GLSL error when `#define` macro exist in `#ifdef` macro body, like the snippet below
    ```glsl
    ......
    #ifdef xxx
      mediump sampler2DShadow scene_ShadowMap;
      #define SAMPLE_TEXTURE2D_SHADOW(textureName, coord3) textureLod(textureName, coord3 , 0.0)
      #define TEXTURE2D_SHADOW_PARAM(shadowMap) mediump sampler2DShadow shadowMap
    #endif
    
    float sampleShadowMapFiltered4(TEXTURE2D_SHADOW_PARAM(shadowMap), vec3 shadowCoord, vec4 shadowMapSize) {
    ......
    ```
4. Fix macro extend error due to  preprocessor not ignoring comments